### PR TITLE
Update Makefile to Keystone-v1.0.0 compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,13 @@ all: bench-runner coremark rv8-bench eyrie-rt
 	./copy_all_tests.sh
 
 coremark:
-	make -C ./coremark/ CC=riscv64-unknown-linux-gnu-gcc link
+	make -C ./coremark/ CC=riscv64-unknown-linux-musl-gcc link
 rv8-bench:
 	make -C ./rv8-bench/
 bench-runner:
 	make -C ./bench-runner/
 eyrie-rt:
-	${KEYSTONE_DIR}/sdk/rts/eyrie/build.sh freemem untrusted_io_syscall env_setup linux_syscall
+	${KEYSTONE_DIR}/keystone-runtime/build.sh freemem untrusted_io_syscall env_setup linux_syscall
 clean:
 	make -C ./rv8-bench clean
 	make -C ./coremark clean

--- a/bench-runner/Makefile
+++ b/bench-runner/Makefile
@@ -1,18 +1,20 @@
 CC = riscv64-unknown-linux-gnu-g++
 OBJCOPY = riscv64-unknown-linux-gnu-objcopy
 
-SDK_LIB_DIR =$(KEYSTONE_DIR)/sdk/lib
+SDK_LIB_DIR =$(KEYSTONE_DIR)/sdk/build64/lib
 SDK_HOST_LIB = $(SDK_LIB_DIR)/libkeystone-host.a
 SDK_EDGE_LIB = $(SDK_LIB_DIR)/libkeystone-edge.a
 SDK_VERIFIER_LIB = $(SDK_LIB_DIR)/libkeystone-verifier.a
 
-SDK_INCLUDE_HOST_DIR = $(SDK_LIB_DIR)/host/include
-SDK_INCLUDE_EDGE_DIR = $(SDK_LIB_DIR)/edge/include
-SDK_INCLUDE_VERIFIER_DIR = $(SDK_LIB_DIR)/verifier
+SDK_INCLUDE_HOST_DIR = $(KEYSTONE_DIR)/sdk/build64/include/host
+SDK_INCLUDE_EDGE_DIR = $(KEYSTONE_DIR)/sdk/build64/include/edge
+SDK_INCLUDE_VERIFIER_DIR = $(KEYSTONE_DIR)/sdk/build64/include/verifier
+SDK_INCLUDE_COMMON_DIR = $(KEYSTONE_DIR)/sdk/build64/include
+SDK_INCLUDE_APP_DIR = $(KEYSTONE_DIR)/sdk/build64/include/app
 
 
 RUNNER=bench-runner.riscv
-CCFLAGS = -I$(SDK_INCLUDE_HOST_DIR) -I$(SDK_INCLUDE_EDGE_DIR) -I$(SDK_INCLUDE_VERIFIER_DIR) -std=c++11
+CCFLAGS = -I$(SDK_INCLUDE_HOST_DIR) -I$(SDK_INCLUDE_EDGE_DIR) -I$(SDK_INCLUDE_VERIFIER_DIR) -I$(SDK_INCLUDE_COMMON_DIR) -std=c++11
 LDFLAGS = -L$(SDK_LIB_DIR)
 
 SRCS = $(patsubst %.riscv, %.cpp, $(RUNNER))

--- a/bench-runner/bench-runner.cpp
+++ b/bench-runner/bench-runner.cpp
@@ -73,8 +73,8 @@ int main(int argc, char** argv)
     }
   }
 
-  Keystone enclave;
-  Params params;
+  Keystone::Enclave enclave;
+  Keystone::Params params;
   unsigned long cycles1,cycles2,cycles3,cycles4;
 
   params.setFreeMemSize(freemem_size);

--- a/copy_all_tests.sh
+++ b/copy_all_tests.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-KEYSTONE_BINS_DIR=${KEYSTONE_DIR}/sdk/rts/eyrie/
+KEYSTONE_BINS_DIR=${KEYSTONE_DIR}/keystone-runtime
 
 source test_config.sh
 


### PR DESCRIPTION
I have updated the Makefile to be compatible with Keystone version v1.0.0 which is currently used in the Keystone Docker image.
I also changed the toolchain for coremark to musl to avoid the current problems with page faults and glibc.
[Runtime Page faults when running hello.ke #229](https://github.com/keystone-enclave/keystone/issues/229)